### PR TITLE
feat:학교정보 파싱 타입 보정 및 기본정보 화면 카카오 미니맵 추가

### DIFF
--- a/src/entities/school/model/SchoolType.ts
+++ b/src/entities/school/model/SchoolType.ts
@@ -250,6 +250,17 @@ export type SchoolInfoListItemByApiType = {
   "51": SchoolInfoListItemApi51;
 };
 
+export type SchoolItem = {
+  item:
+    | SchoolInfoListItemApi0
+    | SchoolInfoListItemApi08
+    | SchoolInfoListItemApi62
+    | SchoolInfoListItemApi63
+    | SchoolInfoListItemApi09
+    | SchoolInfoListItemApi94
+    | SchoolInfoListItemApi51;
+};
+
 type ParsedSchoolInfoResultByType<T extends SchoolInfoApiType> = {
   apiType: T;
   status: number;

--- a/src/features/school-details/hooks/useSchoolInfo.ts
+++ b/src/features/school-details/hooks/useSchoolInfo.ts
@@ -1,12 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type {
+import {
   ParsedSchoolInfoResult,
   SchoolInfoApiPayload,
   SchoolInfoApiType,
   SchoolInfoData,
   SchoolInfoResponse,
+  SchoolItem,
 } from "@/entities/school/model/SchoolType";
 
 type Params = {
@@ -52,7 +53,7 @@ function parseRawResult<T extends SchoolInfoApiType>(
     const parsed = JSON.parse(raw) as SchoolInfoApiPayload;
     const rawItems = Array.isArray(parsed.list) ? parsed.list : [];
     const items = rawItems as ParsedByType<T>["items"];
-    const selectedItem = (selectBySchoolCode(items, schoolCode) ??
+    const selectedItem = (selectBySchoolCode<SchoolItem["item"]>(items, schoolCode) ??
       (items.length === 1 ? items[0] : null)) as ParsedByType<T>["selectedItem"];
 
     return {

--- a/src/widgets/school-detail/ui/SchoolinfoModal.tsx
+++ b/src/widgets/school-detail/ui/SchoolinfoModal.tsx
@@ -2,6 +2,7 @@ import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
 import { useSchoolInfo } from "@/features/school-details/hooks/useSchoolInfo";
 import { SchoolRenderSelected } from "@/widgets/school-detail/ui/schoolInfo/SchoolRenderSelected";
 import { TITLE } from "@/entities/school/model/SchoolType";
+import { KakaoMiniMap } from "@/widgets/kakao-map/ui/KakaoMiniMap";
 
 type Props = {
   open: boolean;
@@ -25,10 +26,7 @@ export function SchoolInfoModal({ open, schoolName, schoolCode, address, onClose
       <div className="fixed inset-0 overflow-y-auto p-4">
         <div className="mx-auto max-w-3xl">
           <DialogPanel className="rounded-lg bg-white p-4 shadow-xl">
-            <DialogTitle className="text-lg font-semibold">
-              {schoolName}
-              {/*({schoolCode})*/}
-            </DialogTitle>
+            <DialogTitle className="text-lg font-semibold">{schoolName}</DialogTitle>
 
             {loading ? <p className="mt-3 text-sm">Loading...</p> : null}
             {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}

--- a/src/widgets/school-detail/ui/schoolInfo/BasicInfo/BasicInfo-0.tsx
+++ b/src/widgets/school-detail/ui/schoolInfo/BasicInfo/BasicInfo-0.tsx
@@ -1,8 +1,9 @@
 import type { SchoolInfoListItemApi0 } from "@/entities/school/model/SchoolType";
+import { KakaoMiniMap } from "@/widgets/kakao-map/ui/KakaoMiniMap";
 
 export const RenderApi0 = (item: SchoolInfoListItemApi0) => {
   return (
-    <div className="mt-2 flex max-h-60 flex-col gap-1 overflow-auto rounded bg-slate-50 p-2 text-xs">
+    <div className="mt-2 flex max-h-90 flex-col gap-1 overflow-auto rounded bg-slate-50 p-2 text-xs">
       <p>{item.ABSCH_YN}</p>
       <p>{item.SCHUL_NM}</p>
       <p>{item.ADRES_BRKDN}</p>
@@ -15,6 +16,9 @@ export const RenderApi0 = (item: SchoolInfoListItemApi0) => {
       <p>{item.USER_TELNO}</p>
       <p>{item.ZIP_CODE}</p>
       <p>{item.PERC_FAXNO}</p>
+      <div>
+        <KakaoMiniMap x={String(item.LGTUD)} y={String(item.LTTUD)} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
요약본 
- 학교 상세 데이터 파싱 타입 보정 시도 + 기본정보 영역에 카카오 미니맵 노출 기능 추가가 한 묶음으로 반영된 상태입니다.