### PR TITLE
feat: UI 리디자인 및 framer-motion 화면 전환 애니메이션 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@tanstack/react-query": "^5.66.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
+        "lucide-react": "^0.577.0",
         "next": "^15.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1372,6 +1374,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1515,6 +1544,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1538,6 +1576,21 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@tanstack/react-query": "^5.66.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
+    "lucide-react": "^0.577.0",
     "next": "^15.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/_pages/apt/ui/AptDetailContent.tsx
+++ b/src/_pages/apt/ui/AptDetailContent.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import type { Variants } from "framer-motion";
+import { motion } from "framer-motion";
 import { Dispatch, SetStateAction } from "react";
 
 import type { NeighborhoodReport, ReportPoi } from "@/entities/report/model/types";
@@ -13,24 +17,53 @@ type Props = {
   setSelectedSchool: Dispatch<SetStateAction<ReportPoi | null>>;
 };
 
+const container: Variants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.08,
+    },
+  },
+};
+
+const item: Variants = {
+  hidden: { opacity: 0, y: 16 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.35, ease: "easeOut" as const } },
+};
+
+
 export function AptDetailContent({ report, selectedSchool, setSelectedSchool }: Props) {
   return (
-    <section className="space-y-5 sm:space-y-6">
-      <AptSummaryCard
-        name={report.place.name}
-        address={report.place.address}
-        x={report.place.x}
-        y={report.place.y}
-      />
-      <div className="rounded-3xl border border-[#dce7f5] bg-white/85 p-4 shadow-[0_8px_24px_rgba(15,23,42,0.05)] sm:p-5">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#6b7684]">Neighborhood</p>
+    <motion.section
+      className="space-y-5 sm:space-y-6"
+      variants={container}
+      initial="hidden"
+      animate="show"
+    >
+      <motion.div variants={item}>
+        <AptSummaryCard
+          name={report.place.name}
+          address={report.place.address}
+          x={report.place.x}
+          y={report.place.y}
+        />
+      </motion.div>
+
+      <motion.div
+        variants={item}
+        className="rounded-2xl border border-[#e5e8eb] bg-white px-5 py-4 shadow-[0_2px_8px_rgba(0,0,0,0.06)] sm:px-6 sm:py-5"
+      >
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#8b95a1]">
+          Neighborhood
+        </p>
         <h1 className="mt-1 text-xl font-extrabold tracking-tight text-[#191f28] sm:text-2xl">
           생활권 상세 리포트
         </h1>
         <p className="mt-2 text-sm text-[#4e5968]">각 항목을 눌러 주요 포인트를 빠르게 확인하세요.</p>
-      </div>
+      </motion.div>
 
-      <div className="grid gap-4 md:grid-cols-2">
+      <motion.div variants={item} className="grid gap-4 md:grid-cols-2">
         <SafetyCard
           fullName={report.safety.fullName}
           grade={report.safety.grade}
@@ -50,7 +83,8 @@ export function AptDetailContent({ report, selectedSchool, setSelectedSchool }: 
           selectedSchool={selectedSchool}
           setSelectedSchool={setSelectedSchool}
         />
-      </div>
-    </section>
+      </motion.div>
+    </motion.section>
   );
 }
+

--- a/src/_pages/apt/ui/AptDetailError.tsx
+++ b/src/_pages/apt/ui/AptDetailError.tsx
@@ -1,11 +1,18 @@
+import { AlertCircle } from "lucide-react";
+
 type Props = {
   message?: string;
 };
 
 export function AptDetailError({ message }: Props) {
   return (
-    <div className="rounded-3xl border border-red-200 bg-red-50 p-5 text-sm text-red-700">
-      리포트를 불러오지 못했습니다. {message ?? "Unknown error"}
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-[#ffe0e0] bg-[#fff5f5] py-14 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#ffe0e0]">
+        <AlertCircle size={22} className="text-[#f04452]" />
+      </div>
+      <p className="mt-4 text-base font-bold text-[#191f28]">리포트를 불러오지 못했습니다</p>
+      <p className="mt-2 text-sm text-[#8b95a1]">{message ?? "알 수 없는 오류가 발생했습니다."}</p>
     </div>
   );
 }
+

--- a/src/_pages/apt/ui/AptDetailLoading.tsx
+++ b/src/_pages/apt/ui/AptDetailLoading.tsx
@@ -2,14 +2,44 @@ import { Skeleton } from "@/shared/ui/skeleton";
 
 export function AptDetailLoading() {
   return (
-    <div className="space-y-4">
-      <Skeleton className="h-52 w-full rounded-3xl" />
+    <div className="space-y-6">
+      {/* 상단 로딩 카드 */}
+      <div className="flex flex-col items-center justify-center rounded-2xl border border-[#e5e8eb] bg-white py-14 shadow-[0_2px_8px_rgba(0,0,0,0.06)]">
+        <div className="toss-spinner" />
+        <p className="mt-5 text-sm font-semibold text-[#191f28]">리포트를 분석하는 중...</p>
+        <p className="mt-1.5 text-xs text-[#b0b8c1]">
+          주변 학교, 교통, 치안 정보를 수집하고 있어요
+        </p>
+
+        {/* 진행 단계 표시 */}
+        <div className="mt-6 flex items-center gap-2">
+          {["단지 정보", "교통", "학군", "치안"].map((label, i) => (
+            <div key={label} className="flex items-center gap-2">
+              {i > 0 && <span className="h-px w-4 bg-[#e5e8eb]" />}
+              <div className="flex flex-col items-center gap-1">
+                <div
+                  className="h-2 w-2 rounded-full bg-[#3182f6]"
+                  style={{
+                    opacity: 0.3 + i * 0.2,
+                    animation: `toss-spin ${0.8 + i * 0.15}s ease-in-out ${i * 0.2}s infinite alternate`,
+                  }}
+                />
+                <span className="text-[10px] text-[#b0b8c1]">{label}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 스켈레톤 카드들 */}
+      <Skeleton className="h-52 w-full" />
       <div className="grid gap-4 md:grid-cols-2">
-        <Skeleton className="h-40 w-full rounded-3xl" />
-        <Skeleton className="h-40 w-full rounded-3xl" />
-        <Skeleton className="h-40 w-full rounded-3xl" />
-        <Skeleton className="h-40 w-full rounded-3xl" />
+        <Skeleton className="h-44 w-full" />
+        <Skeleton className="h-44 w-full" />
+        <Skeleton className="h-44 w-full" />
+        <Skeleton className="h-44 w-full" />
       </div>
     </div>
   );
 }
+

--- a/src/_pages/apt/ui/AptDetailPage.tsx
+++ b/src/_pages/apt/ui/AptDetailPage.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { AnimatePresence, motion } from "framer-motion";
+
 import { useSchoolClickHooks } from "@/features/school-details/hooks/useSchoolClickHooks";
 import { useNeighborhoodReport } from "@/pages/apt/model/useNeighborhoodReport";
 import { AptDetailContent } from "@/pages/apt/ui/AptDetailContent";
@@ -14,23 +16,42 @@ type Props = {
   address?: string;
 };
 
+const pageVariants = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.3, ease: "easeOut" as const } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.2, ease: "easeIn" as const } },
+};
+
 export function AptDetailPage({ placeId, x, y, name, address }: Props) {
   const { selectedSchool, setSelectedSchool } = useSchoolClickHooks();
   const reportQuery = useNeighborhoodReport({ placeId, x, y, name, address });
 
-  if (reportQuery.isLoading) {
-    return <AptDetailLoading />;
-  }
-
-  if (reportQuery.error || !reportQuery.data) {
-    return <AptDetailError message={(reportQuery.error as Error | null)?.message} />;
-  }
+  const stateKey = reportQuery.isLoading ? "loading" : reportQuery.error ? "error" : "content";
 
   return (
-    <AptDetailContent
-      report={reportQuery.data}
-      selectedSchool={selectedSchool}
-      setSelectedSchool={setSelectedSchool}
-    />
+    <AnimatePresence mode="wait">
+      {reportQuery.isLoading && (
+        <motion.div key="loading" {...pageVariants}>
+          <AptDetailLoading />
+        </motion.div>
+      )}
+
+      {!reportQuery.isLoading && (reportQuery.error || !reportQuery.data) && (
+        <motion.div key="error" {...pageVariants}>
+          <AptDetailError message={(reportQuery.error as Error | null)?.message} />
+        </motion.div>
+      )}
+
+      {!reportQuery.isLoading && reportQuery.data && (
+        <motion.div key={`content-${stateKey}`} {...pageVariants}>
+          <AptDetailContent
+            report={reportQuery.data}
+            selectedSchool={selectedSchool}
+            setSelectedSchool={setSelectedSchool}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }
+

--- a/src/_pages/map/ui/MapSearchPage.tsx
+++ b/src/_pages/map/ui/MapSearchPage.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+import type { Variants } from "framer-motion";
+import { motion } from "framer-motion";
+import { BarChart3, BookOpen, Building2, FileDown } from "lucide-react";
+
 import { AptSearchBox } from "@/features/search-apt/ui/AptSearchBox";
 
 const quickKeywords = ["래미안 퍼스티지", "반포자이", "아크로리버파크", "올림픽파크포레온"];
@@ -11,106 +17,149 @@ const stats = [
 
 const features = [
   {
-    icon: <img src={"/images/aptDetail.svg"} alt="map" />,
+    icon: Building2,
+    color: "#e8f3ff",
+    iconColor: "#3182f6",
     title: "단지 상세 분석",
     description: "세대수, 연식, 용적률, 건폐율 등 단지의 핵심 정보를 확인합니다.",
   },
   {
-    icon: <img src={"/images/trans.svg"} alt="map" />,
+    icon: BarChart3,
+    color: "#e5f9f0",
+    iconColor: "#00b493",
     title: "실거래가 추이",
     description: "최근 실거래 데이터와 기준년 대비 흐름을 빠르게 파악할 수 있습니다.",
   },
   {
-    icon: <img src={"/images/infra.svg"} alt="map" />,
+    icon: BookOpen,
+    color: "#fff0e8",
+    iconColor: "#f06000",
     title: "주변 인프라",
     description: "학교, 교통, 보육, 편의시설, 공원 등 생활 편의 지표를 종합 분석합니다.",
   },
   {
-    icon: <img src={"/images/InfoButtonImg.svg"} alt="map" />,
+    icon: FileDown,
+    color: "#f5f0ff",
+    iconColor: "#7248d9",
     title: "리포트 다운로드",
     description: "분석 결과를 PDF로 저장하고 공유할 수 있어 상담 및 비교가 쉽습니다.",
   },
 ];
 
+const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.07 },
+  },
+};
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.4, ease: "easeOut" as const } },
+};
+
 export function MapSearchPage() {
   return (
-    <section className="relative left-1/2 my-[-24px] h-[calc(100dvh-65px)] w-screen -translate-x-1/2 overflow-hidden sm:my-[-32px]">
-      <div className="pointer-events-none absolute inset-0 bg-[#f7fbff]" />
-      <div className="pointer-events-none absolute inset-0 opacity-55 [background-image:linear-gradient(to_right,#dce7f5_1px,transparent_1px),linear-gradient(to_bottom,#dce7f5_1px,transparent_1px)] [background-size:32px_32px]" />
+    <section className="relative left-1/2 my-[-24px] h-[calc(100dvh-56px)] w-screen -translate-x-1/2 overflow-y-auto overflow-x-hidden sm:my-[-32px]">
+      {/* 배경 */}
+      <div className="pointer-events-none absolute inset-0 bg-[#f8fafb]" />
+      <div className="pointer-events-none absolute inset-0 opacity-40 [background-image:linear-gradient(to_right,#e2e8f0_1px,transparent_1px),linear-gradient(to_bottom,#e2e8f0_1px,transparent_1px)] [background-size:40px_40px]" />
 
-      <div className="relative mx-auto flex h-full max-w-4xl flex-col justify-evenly gap-5 px-4 py-4 sm:gap-6 sm:px-8 sm:py-6">
-        <div className="space-y-3 text-center">
-          <div className="inline-flex items-center rounded-full border border-[#dce7f5] bg-white px-3 py-1 text-xs font-semibold text-[#4e5968]">
+      <motion.div
+        className="relative mx-auto flex h-full max-w-4xl flex-col justify-evenly gap-5 px-4 py-6 sm:gap-6 sm:px-8 sm:py-8"
+        variants={containerVariants}
+        initial="hidden"
+        animate="show"
+      >
+        {/* 히어로 섹션 */}
+        <motion.div variants={itemVariants} className="space-y-3 text-center">
+          <div className="inline-flex items-center gap-1.5 rounded-full border border-[#e5e8eb] bg-white px-3 py-1 text-xs font-semibold text-[#4e5968] shadow-[0_1px_4px_rgba(0,0,0,0.06)]">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[#00b493]" />
             실시간 데이터 업데이트 중
           </div>
           <h1 className="text-3xl font-extrabold leading-tight tracking-tight text-[#191f28] sm:text-5xl">
             내 아파트의
             <br />
-            모든 것을 꺼내보세요
+            <span className="text-[#3182f6]">모든 것</span>을 꺼내보세요
           </h1>
-          <p className="mx-auto max-w-2xl text-sm leading-6 text-[#4e5968]">
+          <p className="mx-auto max-w-xl text-sm leading-6 text-[#6b7684]">
             아파트명이나 오피스텔명을 검색하면 실거래가, 단지 정보, 입지 환경까지 한 번에
             보여줍니다.
           </p>
-        </div>
+        </motion.div>
 
-        <div className="mx-auto w-full max-w-3xl space-y-3 rounded-3xl border border-[#dce7f5] bg-white/95 p-4 shadow-[0_12px_28px_rgba(15,23,42,0.07)]">
+        {/* 검색 박스 */}
+        <motion.div
+          variants={itemVariants}
+          className="mx-auto w-full max-w-3xl space-y-3 rounded-2xl border border-[#e5e8eb] bg-white p-4 shadow-[0_4px_16px_rgba(0,0,0,0.08)]"
+        >
           <AptSearchBox />
-          <div className="flex flex-wrap justify-center gap-2">
+          <div className="flex flex-wrap gap-2">
             {quickKeywords.map((item) => (
               <span
                 key={item}
-                className="rounded-full border border-[#dce7f5] bg-[#f8fbff] px-3 py-1 text-xs font-semibold text-[#4e5968]"
+                className="rounded-full border border-[#e5e8eb] bg-[#f8fafb] px-3 py-1 text-xs font-medium text-[#6b7684]"
               >
                 {item}
               </span>
             ))}
           </div>
-        </div>
+        </motion.div>
 
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {/* Stats */}
+        <motion.div variants={itemVariants} className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {stats.map((item) => (
             <div
               key={item.label}
-              className="rounded-2xl border border-[#dce7f5] bg-white p-3 text-center shadow-[0_8px_20px_rgba(15,23,42,0.05)]"
+              className="rounded-2xl border border-[#e5e8eb] bg-white p-3 text-center shadow-[0_1px_4px_rgba(0,0,0,0.04)]"
             >
               <p className="text-xl font-extrabold tracking-tight text-[#191f28] sm:text-2xl">
                 {item.value}
               </p>
-              <p className="mt-1 text-xs font-semibold text-[#6b7684]">{item.label}</p>
+              <p className="mt-0.5 text-xs font-medium text-[#8b95a1]">{item.label}</p>
             </div>
           ))}
-        </div>
+        </motion.div>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          {features.map((item) => (
-            <article
-              key={item.title}
-              className="rounded-2xl border border-[#dce7f5] bg-white p-4 shadow-[0_8px_20px_rgba(15,23,42,0.05)]"
-            >
-              <div className={"flex items-center gap-2"}>
-                <div className={"flex-[0.15]"}>
-                  <h3 className="text-sm font-bold text-[#191f28] sm:text-base">{item.icon}</h3>
+        {/* Features */}
+        <motion.div variants={itemVariants} className="grid gap-3 sm:grid-cols-2">
+          {features.map((item) => {
+            const Icon = item.icon;
+            return (
+              <article
+                key={item.title}
+                className="flex items-start gap-3 rounded-2xl border border-[#e5e8eb] bg-white p-4 shadow-[0_1px_4px_rgba(0,0,0,0.04)]"
+              >
+                <span
+                  className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full"
+                  style={{ backgroundColor: item.color }}
+                >
+                  <Icon size={17} style={{ color: item.iconColor }} />
+                </span>
+                <div>
+                  <h3 className="text-sm font-bold text-[#191f28]">{item.title}</h3>
+                  <p className="mt-1 text-xs leading-5 text-[#6b7684]">{item.description}</p>
                 </div>
+              </article>
+            );
+          })}
+        </motion.div>
 
-                <h3 className="text-sm font-bold text-[#191f28] sm:text-base">{item.title}</h3>
-              </div>
-              <p className="mt-1.5 text-xs leading-5 text-[#4e5968] sm:text-sm">
-                {item.description}
-              </p>
-            </article>
-          ))}
-        </div>
-
-        <div className="rounded-3xl bg-[#191f28] px-6 py-6 text-center text-white shadow-[0_24px_50px_rgba(15,23,42,0.35)]">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#8b95a1]">
+        {/* CTA 배너 */}
+        <motion.div
+          variants={itemVariants}
+          className="rounded-2xl bg-[#191f28] px-6 py-6 text-center text-white shadow-[0_8px_24px_rgba(0,0,0,0.18)]"
+        >
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#6b7684]">
             동네 리포트
           </p>
           <h3 className="mt-2 text-2xl font-extrabold tracking-tight sm:text-3xl">
             지금 바로 검색해보세요
           </h3>
-        </div>
-      </div>
+        </motion.div>
+      </motion.div>
     </section>
   );
 }
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,33 +1,141 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
   color-scheme: light;
-  --bg-start: #f3f7fb;
-  --bg-end: #eaf2fb;
+
+  /* 토스 색상 팔레트 */
+  --bg-main: #f2f4f6;
+  --bg-elevated: #ffffff;
   --surface: #ffffff;
+  --surface-secondary: #f9fafb;
   --surface-soft: #f8fbff;
-  --line: #e5edf7;
+
+  --border-primary: #e5e8eb;
+  --border-secondary: #f2f4f6;
+
   --text-primary: #191f28;
   --text-secondary: #4e5968;
+  --text-tertiary: #8b95a1;
+  --text-disabled: #b0b8c1;
+
   --brand: #3182f6;
+  --brand-light: #e8f3ff;
   --brand-strong: #1b64da;
-  --shadow-soft: 0 10px 40px rgba(15, 23, 42, 0.06);
-  --shadow-card: 0 8px 24px rgba(15, 23, 42, 0.07);
+
+  --success: #00b493;
+  --success-light: #e5f9f0;
+  --warning: #f59e0b;
+  --warning-light: #fffbeb;
+  --error: #f04452;
+  --error-light: #fff0f0;
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
+  --shadow-xl: 0 16px 40px rgba(0, 0, 0, 0.12);
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --radius-2xl: 24px;
+  --radius-full: 9999px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
 }
 
 body {
   margin: 0;
-  min-height: 100vh;
+  min-height: 100dvh;
   overflow-x: hidden;
-  background:
-    radial-gradient(1200px 500px at 100% -10%, rgba(49, 130, 246, 0.16), transparent 60%),
-    linear-gradient(180deg, var(--bg-start) 0%, var(--bg-end) 100%);
+  background-color: var(--bg-main);
   color: var(--text-primary);
-  font-family: "Pretendard", "Noto Sans KR", sans-serif;
+  font-family: "Pretendard Variable", "Pretendard", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  line-height: 1.5;
+  letter-spacing: -0.01em;
 }
 
-* {
-  box-sizing: border-box;
+button {
+  cursor: pointer;
+  font-family: inherit;
 }
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+/* 스크롤바 */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: #d1d8e0;
+  border-radius: 99px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #b0b8c1;
+}
+
+/* 토스 스피너 애니메이션 */
+@keyframes toss-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.toss-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--border-primary);
+  border-top-color: var(--brand);
+  border-radius: 50%;
+  animation: toss-spin 0.8s linear infinite;
+}
+
+.toss-spinner-sm {
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(49, 130, 246, 0.2);
+  border-top-color: var(--brand);
+  border-radius: 50%;
+  animation: toss-spin 0.7s linear infinite;
+}
+
+/* 스켈레톤 shimmer */
+@keyframes shimmer {
+  0% { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+
+.skeleton-shimmer {
+  background: linear-gradient(
+    90deg,
+    #f0f2f5 25%,
+    #e5e8eb 50%,
+    #f0f2f5 75%
+  );
+  background-size: 800px 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,8 @@ import "@/app/globals.css";
 import { Header } from "@/widgets/header/ui/Header";
 
 export const metadata: Metadata = {
-  title: "dongne-report",
-  description: "Neighborhood report for apartment/officetel search",
+  title: "동네리포트",
+  description: "아파트·오피스텔 생활권 분석 서비스",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -15,9 +15,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <Providers>
           <Header />
-          <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 sm:py-8">{children}</main>
+          <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+            {children}
+          </main>
         </Providers>
       </body>
     </html>
   );
 }
+

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -16,5 +16,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
       })
   );
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
 }
+
+

--- a/src/features/search-apt/ui/AptSearchBox.tsx
+++ b/src/features/search-apt/ui/AptSearchBox.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Combobox } from "@headlessui/react";
+import { Building2, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
@@ -66,31 +67,56 @@ export function AptSearchBox() {
       }}
     >
       <div className="relative">
-        <div className="pointer-events-none absolute left-4 top-1/2 z-10 -translate-y-1/2 text-xs font-semibold text-[#8b95a1]">
-          SEARCH
+        {/* Search 아이콘 */}
+        <div className="pointer-events-none absolute left-4 top-1/2 z-10 -translate-y-1/2 text-[#b0b8c1]">
+          <Search size={18} strokeWidth={2} />
         </div>
+
         <Combobox.Input
           as={Input}
           displayValue={(item: KakaoPlace | null) => item?.place_name ?? query}
-          placeholder="아파트/오피스텔명 또는 도로명 주소"
+          placeholder="아파트 / 오피스텔명 또는 도로명 주소"
           onChange={(event) => setQuery(event.target.value)}
-          className="pl-[84px]"
+          className="pl-11"
         />
 
-        <Combobox.Options className="absolute z-20 mt-2 max-h-[22rem] w-full overflow-auto rounded-2xl border border-[#dce7f5] bg-white p-2 shadow-[0_20px_50px_rgba(15,23,42,0.15)]">
-          {loading ? <div className="px-3 py-2 text-sm text-[#6b7684]">검색 중...</div> : null}
-          {empty ? <div className="px-3 py-2 text-sm text-[#6b7684]">검색 결과가 없습니다.</div> : null}
+        {/* 로딩 스피너 (우측) */}
+        {loading && (
+          <div className="absolute right-4 top-1/2 z-10 -translate-y-1/2">
+            <div className="toss-spinner-sm" />
+          </div>
+        )}
+
+        <Combobox.Options className="absolute z-20 mt-2 max-h-[22rem] w-full overflow-auto rounded-2xl border border-[#e5e8eb] bg-white p-1.5 shadow-[0_8px_24px_rgba(0,0,0,0.12)]">
+          {loading && (
+            <div className="flex items-center gap-2 px-3 py-3 text-sm text-[#8b95a1]">
+              <div className="toss-spinner-sm flex-shrink-0" />
+              검색 중...
+            </div>
+          )}
+          {empty && (
+            <div className="px-3 py-4 text-center text-sm text-[#b0b8c1]">
+              검색 결과가 없습니다.
+            </div>
+          )}
           {items.map((item) => (
             <Combobox.Option
               key={item.id}
               value={item}
               className={({ active }) =>
-                `cursor-pointer rounded-xl px-3 py-3 transition ${active ? "bg-[#f2f7ff]" : ""}`
+                `flex cursor-pointer items-center gap-3 rounded-xl px-3 py-3 transition-colors ${
+                  active ? "bg-[#f2f4f6]" : ""
+                }`
               }
             >
-              <div className="text-sm font-semibold text-[#191f28]">{item.place_name}</div>
-              <div className="mt-1 text-xs text-[#6b7684]">
-                {item.road_address_name || item.address_name}
+              <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-[#e8f3ff]">
+                <Building2 size={14} className="text-[#3182f6]" />
+              </span>
+              <div className="min-w-0">
+                <div className="text-sm font-semibold text-[#191f28]">{item.place_name}</div>
+                <div className="mt-0.5 truncate text-xs text-[#8b95a1]">
+                  {item.road_address_name || item.address_name}
+                </div>
               </div>
             </Combobox.Option>
           ))}
@@ -99,3 +125,4 @@ export function AptSearchBox() {
     </Combobox>
   );
 }
+

--- a/src/shared/ui/card.tsx
+++ b/src/shared/ui/card.tsx
@@ -6,7 +6,7 @@ export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
   return (
     <div
       className={cn(
-        "rounded-3xl border border-[#dce7f5] bg-white shadow-[0_8px_24px_rgba(15,23,42,0.07)]",
+        "rounded-2xl border border-[#e5e8eb] bg-white shadow-[0_2px_8px_rgba(0,0,0,0.06)]",
         className
       )}
       {...props}
@@ -15,13 +15,19 @@ export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
 }
 
 export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("p-5 pb-2 sm:p-6 sm:pb-2", className)} {...props} />;
+  return <div className={cn("px-5 pt-5 pb-3 sm:px-6 sm:pt-6 sm:pb-3", className)} {...props} />;
 }
 
 export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  return <h3 className={cn("text-lg font-bold text-[#191f28]", className)} {...props} />;
+  return (
+    <h3
+      className={cn("text-base font-bold text-[#191f28] tracking-tight", className)}
+      {...props}
+    />
+  );
 }
 
 export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("p-5 pt-0 sm:p-6 sm:pt-0", className)} {...props} />;
+  return <div className={cn("px-5 pb-5 sm:px-6 sm:pb-6", className)} {...props} />;
 }
+

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -10,8 +10,10 @@ export const Input = React.forwardRef<
     <input
       ref={ref}
       className={cn(
-        "h-12 w-full rounded-2xl border border-[#d4e1f2] bg-white px-4 py-3 text-sm text-[#191f28] outline-none transition",
-        "placeholder:text-[#8b95a1] focus-visible:border-[#3182f6] focus-visible:ring-4 focus-visible:ring-[#3182f6]/15",
+        "h-14 w-full rounded-2xl border border-[#e5e8eb] bg-white px-5 py-3.5 text-[15px] font-medium text-[#191f28] outline-none transition-all duration-150",
+        "placeholder:text-[#b0b8c1] placeholder:font-normal",
+        "focus:border-[#3182f6] focus:ring-4 focus:ring-[#3182f6]/10",
+        "hover:border-[#c9d3dd]",
         className
       )}
       {...props}
@@ -19,3 +21,4 @@ export const Input = React.forwardRef<
   );
 });
 Input.displayName = "Input";
+

--- a/src/shared/ui/skeleton.tsx
+++ b/src/shared/ui/skeleton.tsx
@@ -1,5 +1,11 @@
 import { cn } from "@/shared/lib/cn";
 
 export function Skeleton({ className }: { className?: string }) {
-  return <div className={cn("animate-pulse rounded-md bg-muted", className)} />;
+  return (
+    <div
+      className={cn("skeleton-shimmer rounded-2xl", className)}
+      aria-hidden="true"
+    />
+  );
 }
+

--- a/src/widgets/apt-summary/ui/AptSummaryCard.tsx
+++ b/src/widgets/apt-summary/ui/AptSummaryCard.tsx
@@ -1,3 +1,5 @@
+import { MapPin } from "lucide-react";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { KakaoMiniMap } from "@/widgets/kakao-map/ui/KakaoMiniMap";
 
@@ -10,13 +12,14 @@ type Props = {
 
 export function AptSummaryCard({ name, address, x, y }: Props) {
   return (
-    <Card className="overflow-hidden border-[#dce7f5]">
+    <Card className="overflow-hidden">
       <CardHeader>
         <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded-full bg-[#e9f2ff] px-3 py-1 text-xs font-semibold text-[#1b64da]">
+          <span className="inline-flex items-center gap-1 rounded-full bg-[#e8f3ff] px-2.5 py-1 text-xs font-semibold text-[#3182f6]">
+            <MapPin size={11} strokeWidth={2.5} />
             선택한 단지
           </span>
-          <CardTitle>{name}</CardTitle>
+          <CardTitle className="text-lg">{name}</CardTitle>
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -26,3 +29,4 @@ export function AptSummaryCard({ name, address, x, y }: Props) {
     </Card>
   );
 }
+

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,27 +1,51 @@
+"use client";
+
+import { Home, MapPin } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export function Header() {
+  const pathname = usePathname();
+
   return (
-    <header className="sticky top-0 z-40 border-b border-[#dce7f5]/80 bg-white/75 backdrop-blur-xl">
-      <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-4 sm:px-6">
-        <Link href="/" className="inline-flex items-center gap-2 text-sm font-bold text-[#1b64da]">
-          <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#3182f6] text-white">
-            D
+    <header className="sticky top-0 z-40 border-b border-[#e5e8eb] bg-white/90 backdrop-blur-xl">
+      <div className="mx-auto flex h-14 w-full max-w-6xl items-center justify-between px-4 sm:px-6">
+        {/* 로고 */}
+        <Link href="/" className="inline-flex items-center gap-2 group">
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#3182f6] text-white shadow-[0_2px_8px_rgba(49,130,246,0.4)] transition-transform group-hover:scale-105">
+            <Home size={15} strokeWidth={2.5} />
           </span>
-          dongne-report
+          <span className="text-[15px] font-bold text-[#191f28] tracking-tight">
+            동네리포트
+          </span>
         </Link>
-        <nav className="flex items-center gap-1 rounded-full border border-[#dce7f5] bg-white p-1 text-sm text-[#4e5968] shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
-          <Link href="/" className="rounded-full px-3 py-1.5 transition hover:bg-[#f2f7ff] hover:text-[#1b64da]">
-            Search
+
+        {/* 네비게이션 */}
+        <nav className="flex items-center gap-1">
+          <Link
+            href="/"
+            className={`flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-sm font-medium transition-all duration-150 ${
+              pathname === "/"
+                ? "bg-[#e8f3ff] text-[#3182f6]"
+                : "text-[#4e5968] hover:bg-[#f2f4f6] hover:text-[#191f28]"
+            }`}
+          >
+            <MapPin size={14} strokeWidth={2} />
+            검색
           </Link>
           <Link
             href="/about"
-            className="rounded-full px-3 py-1.5 transition hover:bg-[#f2f7ff] hover:text-[#1b64da]"
+            className={`rounded-xl px-3 py-1.5 text-sm font-medium transition-all duration-150 ${
+              pathname === "/about"
+                ? "bg-[#e8f3ff] text-[#3182f6]"
+                : "text-[#4e5968] hover:bg-[#f2f4f6] hover:text-[#191f28]"
+            }`}
           >
-            About
+            소개
           </Link>
         </nav>
       </div>
     </header>
   );
 }
+

--- a/src/widgets/report-sections/ui/ChildcareCard.tsx
+++ b/src/widgets/report-sections/ui/ChildcareCard.tsx
@@ -1,3 +1,5 @@
+import { Baby } from "lucide-react";
+
 import type { ReportPoi } from "@/entities/report/model/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 
@@ -10,20 +12,38 @@ export function ChildcareCard({ count, top5 }: Props) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>보육</CardTitle>
+        <div className="flex items-center gap-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#fff0f0]">
+            <Baby size={16} className="text-[#f04452]" />
+          </span>
+          <CardTitle>보육</CardTitle>
+        </div>
       </CardHeader>
-      <CardContent className="space-y-3 text-sm text-[#4e5968]">
-        <p>어린이집/유치원 (1km): 총 {count}개</p>
-        <div className="rounded-2xl bg-[#f8fbff] p-3">
-          <p className="mb-2 text-sm font-semibold text-[#191f28]">주변 시설 Top 5</p>
-          <ul className="space-y-1">
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-[#fff0f0] px-3 py-1 text-xs font-semibold text-[#f04452]">
+            어린이집·유치원 (1km) 총 {count}개
+          </span>
+        </div>
+
+        <div className="rounded-xl bg-[#f9fafb] p-3">
+          <p className="mb-2.5 text-xs font-semibold uppercase tracking-wide text-[#8b95a1]">
+            주변 시설 Top 5
+          </p>
+          <ul className="space-y-1.5">
             {top5.map((item) => (
-              <li key={item.id}>• {item.name}</li>
+              <li key={item.id} className="flex items-center gap-2 text-sm text-[#191f28]">
+                <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#f04452]" />
+                {item.name}
+              </li>
             ))}
-            {!top5.length ? <li>데이터가 없습니다.</li> : null}
+            {!top5.length && (
+              <li className="text-sm text-[#b0b8c1]">데이터가 없습니다.</li>
+            )}
           </ul>
         </div>
       </CardContent>
     </Card>
   );
 }
+

--- a/src/widgets/report-sections/ui/SafetyCard.tsx
+++ b/src/widgets/report-sections/ui/SafetyCard.tsx
@@ -1,3 +1,5 @@
+import { Shield } from "lucide-react";
+
 import { Badge } from "@/shared/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 
@@ -21,16 +23,38 @@ export function SafetyCard({ fullName, grade, crimePer100k }: Props) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>치안</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3 text-sm text-[#4e5968]">
-        <p>기준 지역: {fullName || "매칭 실패"}</p>
         <div className="flex items-center gap-2">
-          <span className="font-medium text-[#191f28]">등급</span>
-          <Badge className={gradeTone(grade)}>{grade}</Badge>
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#e5f9f0]">
+            <Shield size={16} className="text-[#00b493]" />
+          </span>
+          <CardTitle>치안</CardTitle>
         </div>
-        <p>인구 10만 명당 범죄: {crimePer100k ?? "N/A"}</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="rounded-xl bg-[#f9fafb] p-3">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#8b95a1]">
+            기준 지역
+          </p>
+          <p className="text-sm font-medium text-[#191f28]">{fullName || "매칭 실패"}</p>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-[#191f28]">안전 등급</span>
+            <Badge className={gradeTone(grade)}>{grade}</Badge>
+          </div>
+        </div>
+
+        <div className="rounded-xl bg-[#f9fafb] p-3">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#8b95a1]">
+            인구 10만 명당 범죄
+          </p>
+          <p className="text-lg font-bold text-[#191f28]">
+            {crimePer100k !== null ? crimePer100k.toLocaleString() : "N/A"}
+          </p>
+        </div>
       </CardContent>
     </Card>
   );
 }
+

--- a/src/widgets/report-sections/ui/SchoolCard.tsx
+++ b/src/widgets/report-sections/ui/SchoolCard.tsx
@@ -1,3 +1,4 @@
+import { ChevronRight, GraduationCap } from "lucide-react";
 import { Dispatch, SetStateAction } from "react";
 
 import type { ReportPoi } from "@/entities/report/model/types";
@@ -25,38 +26,69 @@ export function SchoolCard({
     <>
       <Card>
         <CardHeader>
-          <CardTitle>학군</CardTitle>
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#fff0e8]">
+              <GraduationCap size={16} className="text-[#f06000]" />
+            </span>
+            <CardTitle>학군</CardTitle>
+          </div>
         </CardHeader>
-        <CardContent className="space-y-3 text-sm text-[#4e5968]">
-          <div className="rounded-2xl bg-[#f8fbff] p-3">
-            <p>학교 (1.5km): 총 {count}개</p>
-            <p className="mt-1">코드 매핑 {mappedCount}개 / 미매핑 {unmappedCount}개</p>
+        <CardContent className="space-y-3">
+          {/* 요약 배지 */}
+          <div className="flex flex-wrap gap-2">
+            <span className="rounded-full bg-[#f9fafb] px-3 py-1 text-xs font-semibold text-[#4e5968]">
+              학교 (1.5km) 총 {count}개
+            </span>
+            <span className="rounded-full bg-[#e8f3ff] px-3 py-1 text-xs font-semibold text-[#3182f6]">
+              코드 매핑 {mappedCount}개
+            </span>
+            <span className="rounded-full bg-[#f9fafb] px-3 py-1 text-xs font-semibold text-[#8b95a1]">
+              미매핑 {unmappedCount}개
+            </span>
           </div>
 
+          {/* 학교 목록 */}
           <ul className="space-y-2">
             {top10.map((item) => {
               const disabled = !item.schoolCode;
               return (
-                <li key={item.id} className="rounded-2xl border border-[#e6eef9] bg-white p-3">
+                <li key={item.id}>
                   <button
                     type="button"
                     onClick={() => setSelectedSchool(item)}
                     disabled={disabled}
-                    className="w-full text-left disabled:cursor-not-allowed disabled:opacity-60"
+                    className={`group w-full rounded-xl border p-3 text-left transition-all duration-150 ${
+                      disabled
+                        ? "cursor-not-allowed border-[#f2f4f6] bg-[#f9fafb] opacity-60"
+                        : "border-[#e5e8eb] bg-white hover:border-[#3182f6] hover:bg-[#f8fbff]"
+                    }`}
                   >
-                    <p className="text-sm font-semibold text-[#191f28]">{item.name}</p>
-                    <p className="mt-1 text-xs text-[#6b7684]">{item.roadAddress || item.address}</p>
-                    <p className="mt-1 text-xs text-[#4e5968]">schoolCode: {item.schoolCode ?? "N/A"}</p>
-                    {disabled ? (
-                      <p className="mt-1 text-xs font-semibold text-[#b26a00]">
-                        학교 코드가 없어 상세 조회가 불가능합니다.
-                      </p>
-                    ) : null}
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-[#191f28]">{item.name}</p>
+                        <p className="mt-0.5 truncate text-xs text-[#6b7684]">
+                          {item.roadAddress || item.address}
+                        </p>
+                        {disabled && (
+                          <p className="mt-1 text-xs font-medium text-[#f04452]">
+                            학교 코드 없음 · 상세 조회 불가
+                          </p>
+                        )}
+                      </div>
+                      {!disabled && (
+                        <ChevronRight
+                          size={16}
+                          className="flex-shrink-0 text-[#b0b8c1] transition-colors group-hover:text-[#3182f6]"
+                        />
+                      )}
+                    </div>
                   </button>
                 </li>
               );
             })}
-            {!top10.length ? <li>데이터가 없습니다.</li> : null}
+            {!top10.length && (
+              <li className="py-2 text-sm text-[#b0b8c1]">데이터가 없습니다.</li>
+            )}
           </ul>
         </CardContent>
       </Card>
@@ -71,3 +103,4 @@ export function SchoolCard({
     </>
   );
 }
+

--- a/src/widgets/report-sections/ui/TransportCard.tsx
+++ b/src/widgets/report-sections/ui/TransportCard.tsx
@@ -1,3 +1,5 @@
+import { Bus, Train } from "lucide-react";
+
 import type { ReportPoi } from "@/entities/report/model/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 
@@ -11,29 +13,57 @@ export function TransportCard({ subwayTop3, busCount, busTop5 }: Props) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>교통</CardTitle>
+        <div className="flex items-center gap-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#e8f3ff]">
+            <Train size={16} className="text-[#3182f6]" />
+          </span>
+          <CardTitle>교통</CardTitle>
+        </div>
       </CardHeader>
-      <CardContent className="space-y-4 text-sm text-[#4e5968]">
-        <div className="rounded-2xl bg-[#f8fbff] p-3">
-          <p className="mb-2 text-sm font-semibold text-[#191f28]">지하철역 Top 3 (1km)</p>
-          <ul className="space-y-1">
+      <CardContent className="space-y-4">
+        {/* 지하철 */}
+        <div className="rounded-xl bg-[#f9fafb] p-3">
+          <p className="mb-2.5 text-xs font-semibold uppercase tracking-wide text-[#8b95a1]">
+            지하철역 Top 3 (1km)
+          </p>
+          <ul className="space-y-1.5">
             {subwayTop3.map((item) => (
-              <li key={item.id}>• {item.name}</li>
+              <li key={item.id} className="flex items-center gap-2 text-sm text-[#191f28]">
+                <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#3182f6]" />
+                {item.name}
+              </li>
             ))}
-            {!subwayTop3.length ? <li>데이터가 없습니다.</li> : null}
+            {!subwayTop3.length && (
+              <li className="text-sm text-[#b0b8c1]">데이터가 없습니다.</li>
+            )}
           </ul>
         </div>
-        <div className="rounded-2xl bg-[#f8fbff] p-3">
-          <p className="mb-2 text-sm font-semibold text-[#191f28]">버스정류장 (1km)</p>
-          <p className="mb-2">총 {busCount}개</p>
-          <ul className="space-y-1">
+
+        {/* 버스 */}
+        <div className="rounded-xl bg-[#f9fafb] p-3">
+          <div className="mb-2.5 flex items-center gap-2">
+            <Bus size={13} className="text-[#4e5968]" />
+            <p className="text-xs font-semibold uppercase tracking-wide text-[#8b95a1]">
+              버스정류장 (1km)
+            </p>
+            <span className="ml-auto rounded-full bg-[#e8f3ff] px-2 py-0.5 text-xs font-bold text-[#3182f6]">
+              총 {busCount}개
+            </span>
+          </div>
+          <ul className="space-y-1.5">
             {busTop5.map((item) => (
-              <li key={item.id}>• {item.name}</li>
+              <li key={item.id} className="flex items-center gap-2 text-sm text-[#191f28]">
+                <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#4e5968]" />
+                {item.name}
+              </li>
             ))}
-            {!busTop5.length ? <li>데이터가 없습니다.</li> : null}
+            {!busTop5.length && (
+              <li className="text-sm text-[#b0b8c1]">데이터가 없습니다.</li>
+            )}
           </ul>
         </div>
       </CardContent>
     </Card>
   );
 }
+


### PR DESCRIPTION
#### 이슈번호
#9 


#### 요약본
- framer-motion + lucide-react 패키지 추가. 
- Pretendard 웹폰트 및 토스 디자인 시스템 CSS 변수 적용. 
- AnimatePresence로 로딩→에러→컨텐츠 전환 애니메이션 구현.
-  검색창에 실시간 스피너 및 Building2 아이콘 드롭다운 추가.
-  상세 페이지 전체화면 로딩 UI(단계 표시 + shimmer 스켈레톤) 구현.
-  홈 히어로 섹션 등장 애니메이션 적용.