### PR TITLE
feat:학원 데이터 연동 추가 및 리포트 카드 UI 개선

### DIFF
--- a/src/_pages/apt/ui/AptDetailContent.tsx
+++ b/src/_pages/apt/ui/AptDetailContent.tsx
@@ -10,6 +10,7 @@ import { ChildcareCard } from "@/widgets/report-sections/ui/ChildcareCard";
 import { SafetyCard } from "@/widgets/report-sections/ui/SafetyCard";
 import { SchoolCard } from "@/widgets/report-sections/ui/SchoolCard";
 import { TransportCard } from "@/widgets/report-sections/ui/TransportCard";
+import { AcademyCard } from "@/widgets/report-sections/ui/AcademyCard";
 
 type Props = {
   report: NeighborhoodReport;
@@ -78,14 +79,7 @@ export function AptDetailContent({ report, selectedSchool, setSelectedSchool }: 
           busTop5={report.transport.busTop5}
           distance={report.carDistance}
         />
-        <SchoolCard
-          count={report.schools.count}
-          mappedCount={report.schools.mappedCount}
-          unmappedCount={report.schools.unmappedCount}
-          top10={report.schools.top10}
-          selectedSchool={selectedSchool}
-          setSelectedSchool={setSelectedSchool}
-        />
+        <AcademyCard count={report.academy.count} academy={report.academy.academy} />
         <SchoolCard
           count={report.schools.count}
           mappedCount={report.schools.mappedCount}

--- a/src/app/api/report/[placeId]/route.ts
+++ b/src/app/api/report/[placeId]/route.ts
@@ -15,6 +15,7 @@ const CATEGORY = {
   SUBWAY: "SW8",
   SCHOOL: "SC4",
   CHILDCARE: "PS3",
+  ACADEMY: "AC5",
 } as const;
 
 function toReportPoi(place: KakaoPlace, schoolCode?: string | null): ReportPoi {
@@ -103,7 +104,7 @@ async function buildReport(params: {
       grade: "UNKNOWN",
     };
 
-    const [subway, schools, childcare, buses, distanceResult] = await Promise.all([
+    const [subway, schools, childcare, buses, academy, distanceResult] = await Promise.all([
       getKakaoCategorySearchCached({
         category_group_code: CATEGORY.SUBWAY,
         x: resolvedX,
@@ -128,8 +129,17 @@ async function buildReport(params: {
         page: 1,
         size: 15,
       }),
+
       getKakaoKeywordSearchCached({
         query: "버스정류장",
+        x: resolvedX,
+        y: resolvedY,
+        radius: 1000,
+        page: 1,
+        size: 15,
+      }),
+      getKakaoCategorySearchCached({
+        category_group_code: CATEGORY.ACADEMY,
         x: resolvedX,
         y: resolvedY,
         radius: 1000,
@@ -142,7 +152,7 @@ async function buildReport(params: {
         y: resolvedY,
       }),
     ]);
-
+    console.log(academy);
     const topRoute = distanceResult.current.routes[0];
     const routeSummary = topRoute?.summary;
     const distanceKm =
@@ -191,6 +201,10 @@ async function buildReport(params: {
         top10: schoolPois.slice(0, 10),
         mappedCount,
         unmappedCount: schoolPois.length - mappedCount,
+      },
+      academy: {
+        count: academy.documents.length,
+        academy: academy.documents,
       },
       carDistance: {
         routeCount: distanceResult.current.routes.length,

--- a/src/entities/kakao/model/types.ts
+++ b/src/entities/kakao/model/types.ts
@@ -8,6 +8,7 @@ export type KakaoPlace = {
   category_group_code?: string;
   category_group_name?: string;
   place_url?: string;
+  distance?: string;
 };
 
 export type KakaoSearchResponse = {

--- a/src/entities/report/model/types.ts
+++ b/src/entities/report/model/types.ts
@@ -1,4 +1,4 @@
-import type { KakaoPoint } from "@/entities/kakao/model/types";
+import { KakaoPlace, KakaoPoint } from "@/entities/kakao/model/types";
 
 export type ReportPoi = {
   id: string;
@@ -17,6 +17,11 @@ export type Xy = {
 
 export interface WayPoint extends Xy {
   name: string;
+}
+
+export interface Academy {
+  count: number;
+  academy: KakaoPlace[];
 }
 
 export type ReportDurationSec = {
@@ -77,5 +82,6 @@ export type NeighborhoodReport = {
   transport: ReportTransport;
   childcare: ReportChildcare;
   schools: ReportSchools;
+  academy: Academy;
   carDistance: ReportCarDistance;
 };

--- a/src/widgets/report-sections/ui/AcademyCard.tsx
+++ b/src/widgets/report-sections/ui/AcademyCard.tsx
@@ -1,0 +1,60 @@
+import { Baby, Footprints, Timer, University } from "lucide-react";
+
+import type { Academy, ReportPoi } from "@/entities/report/model/types";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
+import { KakaoPlace } from "@/entities/kakao/model/types";
+
+type Props = {
+  count: number;
+  academy: KakaoPlace[];
+};
+
+export function AcademyCard({ count, academy }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#E0E7FF]">
+            <University size={16} className="text-[#4F46E5]" />
+          </span>
+          <CardTitle>학원</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-[#E0E7FF] px-3 py-1 text-xs font-semibold text-[#4F46E5]">
+            학원 (1km) 총 {count}개
+          </span>
+        </div>
+
+        <div className="rounded-xl bg-[#f9fafb] p-3">
+          <p className="mb-2.5 text-xs font-semibold uppercase tracking-wide text-[#8b95a1]">
+            주변 학원 시설
+          </p>
+          <ul className="space-y-1.5">
+            {academy.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center justify-between text-sm text-[#191f28]"
+              >
+                <span className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#4F46E5]" />
+                  {item.place_name}
+                </span>
+
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-between gap-1 rounded-full bg-[#E0E7FF] px-2 py-0.5 text-xs font-bold text-[#4F46E5] w-16"
+                >
+                  <Footprints size={12} />
+                  <p>{`${item.distance}m`}</p>
+                </button>
+              </li>
+            ))}
+            {!academy.length && <li className="text-sm text-[#b0b8c1]">데이터가 없습니다.</li>}
+          </ul>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/widgets/report-sections/ui/ChildcareCard.tsx
+++ b/src/widgets/report-sections/ui/ChildcareCard.tsx
@@ -1,6 +1,6 @@
 import { Baby } from "lucide-react";
 
-import type { ReportPoi } from "@/entities/report/model/types";
+import type { Academy, ReportPoi } from "@/entities/report/model/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 
 type Props = {
@@ -37,13 +37,10 @@ export function ChildcareCard({ count, top5 }: Props) {
                 {item.name}
               </li>
             ))}
-            {!top5.length && (
-              <li className="text-sm text-[#b0b8c1]">데이터가 없습니다.</li>
-            )}
+            {!top5.length && <li className="text-sm text-[#b0b8c1]">데이터가 없습니다.</li>}
           </ul>
         </div>
       </CardContent>
     </Card>
   );
 }
-

--- a/src/widgets/report-sections/ui/TransportCard.tsx
+++ b/src/widgets/report-sections/ui/TransportCard.tsx
@@ -1,4 +1,4 @@
-import { Bus, Car, MapPinned, Timer, Train } from "lucide-react";
+import { Bus, Car, Clock, MapPinned, Timer, Train } from "lucide-react";
 
 import { ReportCarDistance, ReportPoi } from "@/entities/report/model/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
@@ -118,17 +118,34 @@ export function TransportCard({ subwayTop3, busCount, busTop5, distance }: Props
 
         <div className="rounded-xl bg-[#f9fafb] p-3">
           <div className="mb-2.5 flex items-center gap-2">
-            <Timer size={13} className="text-[#4e5968]" />
-            <p className="text-xs font-semibold uppercase tracking-wide text-[#8b95a1]">소요시간</p>
+            <Clock size={13} className="text-[#4e5968]" />
+            <span className={"flex-col"}>
+              <p className="text-xs font-semibold uppercase tracking-wide text-[#8b95a1]">
+                소요시간
+              </p>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-[#8b95a1]">
+                예상시간이오니 정확하지 않을수 있습니다.
+              </p>
+            </span>
           </div>
-          <ul className="space-y-1.5">
+          <ul className="space-y-1.5 list-none pl-0 m-0">
             {timeSlots.map((slot) => (
               <li
                 key={slot.label}
-                className="flex items-center justify-between text-sm text-[#4e5968]"
+                className="flex items-center justify-between text-sm text-[#191f28]"
               >
-                <span>{slot.label}</span>
-                <span className="font-semibold text-[#191f28]">{slot.value}</span>
+                <span className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#3182f6]" />
+                  {slot.label}
+                </span>
+
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded-full bg-[#e8f3ff] px-2 py-0.5 text-xs font-bold text-[#3182f6]"
+                >
+                  <Timer size={12} />
+                  {`${slot.value}`}
+                </button>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
#### 이슈번호
#18 

#### 요약본
- 학원 데이터를 API-타입-화면까지 연결하고, 학원/교통 카드의 가독성과 표현 방식을 개선