### PR TITLE
feat:학교 POI 거리(km) 계산 및 학교 카드 거리 표시 추가

### DIFF
--- a/src/app/api/report/[placeId]/route.ts
+++ b/src/app/api/report/[placeId]/route.ts
@@ -18,7 +18,7 @@ const CATEGORY = {
   ACADEMY: "AC5",
 } as const;
 
-function toReportPoi(place: KakaoPlace, schoolCode?: string | null): ReportPoi {
+function toReportPoi(place: KakaoPlace, schoolCode?: string | null, distance?: number): ReportPoi {
   return {
     id: place.id,
     name: place.place_name,
@@ -27,6 +27,7 @@ function toReportPoi(place: KakaoPlace, schoolCode?: string | null): ReportPoi {
     x: place.x,
     y: place.y,
     schoolCode,
+    distance: distance,
   };
 }
 
@@ -152,7 +153,7 @@ async function buildReport(params: {
         y: resolvedY,
       }),
     ]);
-    console.log(academy);
+
     const topRoute = distanceResult.current.routes[0];
     const routeSummary = topRoute?.summary;
     const distanceKm =
@@ -167,7 +168,10 @@ async function buildReport(params: {
         sigungu,
         kakaoRoadAddress: school.road_address_name,
       });
-      schoolPois.push(toReportPoi(school, schoolCode));
+      const m = Number(school.distance);
+      const km = Number.isFinite(m) ? Number((m / 1000).toFixed(2)) : undefined;
+
+      schoolPois.push(toReportPoi(school, schoolCode, km));
     }
 
     const mappedCount = schoolPois.filter((s) => s.schoolCode).length;

--- a/src/entities/report/model/types.ts
+++ b/src/entities/report/model/types.ts
@@ -8,6 +8,7 @@ export type ReportPoi = {
   x: string;
   y: string;
   schoolCode?: string | null;
+  distance?: number;
 };
 
 export type Xy = {

--- a/src/features/search-apt/ui/AptSearchBox.tsx
+++ b/src/features/search-apt/ui/AptSearchBox.tsx
@@ -46,7 +46,7 @@ export function AptSearchBox() {
       try {
         const response = await fetch(`/api/kakao/search?query=${encodeURIComponent(debounced)}`);
         const json = (await response.json()) as { documents?: KakaoPlace[] };
-        console.log(json);
+
         if (mounted) setItems(json.documents ?? []);
       } finally {
         if (mounted) setLoading(false);

--- a/src/widgets/report-sections/ui/AcademyCard.tsx
+++ b/src/widgets/report-sections/ui/AcademyCard.tsx
@@ -1,6 +1,4 @@
-import { Baby, Footprints, Timer, University } from "lucide-react";
-
-import type { Academy, ReportPoi } from "@/entities/report/model/types";
+import { Footprints, University } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { KakaoPlace } from "@/entities/kakao/model/types";
 

--- a/src/widgets/report-sections/ui/SchoolCard.tsx
+++ b/src/widgets/report-sections/ui/SchoolCard.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, GraduationCap } from "lucide-react";
+import { ChevronRight, Footprints, GraduationCap, PersonStanding, Timer } from "lucide-react";
 import { Dispatch, SetStateAction } from "react";
 
 import type { ReportPoi } from "@/entities/report/model/types";
@@ -36,15 +36,15 @@ export function SchoolCard({
         <CardContent className="space-y-3">
           {/* 요약 배지 */}
           <div className="flex flex-wrap gap-2">
-            <span className="rounded-full bg-[#f9fafb] px-3 py-1 text-xs font-semibold text-[#4e5968]">
+            <span className="rounded-full bg-[#fff0e8] px-3 py-1 text-xs font-semibold text-[#f06000]">
               학교 (1.5km) 총 {count}개
             </span>
-            <span className="rounded-full bg-[#e8f3ff] px-3 py-1 text-xs font-semibold text-[#3182f6]">
-              코드 매핑 {mappedCount}개
-            </span>
-            <span className="rounded-full bg-[#f9fafb] px-3 py-1 text-xs font-semibold text-[#8b95a1]">
-              미매핑 {unmappedCount}개
-            </span>
+            {/*<span className="rounded-full bg-[#e8f3ff] px-3 py-1 text-xs font-semibold text-[#3182f6]">*/}
+            {/*  코드 매핑 {mappedCount}개*/}
+            {/*</span>*/}
+            {/*<span className="rounded-full bg-[#f9fafb] px-3 py-1 text-xs font-semibold text-[#8b95a1]">*/}
+            {/*   {unmappedCount}개*/}
+            {/*</span>*/}
           </div>
 
           {/* 학교 목록 */}
@@ -69,6 +69,18 @@ export function SchoolCard({
                         <p className="mt-0.5 truncate text-xs text-[#6b7684]">
                           {item.roadAddress || item.address}
                         </p>
+                        <p className="mt-0.5 truncate text-xs text-[#6b7684] flex items-center gap-2">
+                          <li className="flex items-center justify-between text-sm text-[#191f28]">
+                            <button
+                              type="button"
+                              className="inline-flex items-center gap-1 rounded-full bg-[#fff0e8] px-2 py-0.5 text-xs font-bold text-[#f06000]"
+                            >
+                              <Footprints size={12} />
+                              {item.distance} km
+                            </button>
+                          </li>
+                        </p>
+
                         {disabled && (
                           <p className="mt-1 text-xs font-medium text-[#f04452]">
                             학교 코드 없음 · 상세 조회 불가
@@ -86,9 +98,7 @@ export function SchoolCard({
                 </li>
               );
             })}
-            {!top10.length && (
-              <li className="py-2 text-sm text-[#b0b8c1]">데이터가 없습니다.</li>
-            )}
+            {!top10.length && <li className="py-2 text-sm text-[#b0b8c1]">데이터가 없습니다.</li>}
           </ul>
         </CardContent>
       </Card>
@@ -103,4 +113,3 @@ export function SchoolCard({
     </>
   );
 }
-


### PR DESCRIPTION
#### 이슈 번호
#20 

#### 요약본
•학교 거리 데이터를 API에서 계산해 프론트 카드까지 전달하고 표시하는 흐름을 연결함
