### PR TITLE
style:아파트 요약 카드 호버 스타일 개선 및 카테고리 칩 UI 정리

### DIFF
--- a/src/widgets/apt-summary/ui/AptSummaryCard.tsx
+++ b/src/widgets/apt-summary/ui/AptSummaryCard.tsx
@@ -1,4 +1,4 @@
-import { MapPin } from "lucide-react";
+import {Baby, GraduationCap, Hospital, MapPin, Train, University} from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { KakaoMiniMap } from "@/widgets/kakao-map/ui/KakaoMiniMap";
@@ -10,9 +10,42 @@ type Props = {
   y: string;
 };
 
+const summaryTags = [
+  {
+    label: "보육",
+    icon: Baby,
+    className:
+      "bg-[#fff0f0] text-[#f04452] shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] hover:bg-[#ffe4e6] hover:shadow-[0_2px_10px_rgba(240,68,82,0.16)]",
+  },
+  {
+    label: "교통",
+    icon: Train,
+    className:
+      "bg-[#e8f3ff] text-[#3182f6] shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] hover:bg-[#dbeafe] hover:shadow-[0_2px_10px_rgba(49,130,246,0.16)]",
+  },
+  {
+    label: "병원",
+    icon: Hospital,
+    className:
+      "bg-[#f3eeff] text-[#8b5cf6] shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] hover:bg-[#ede9fe] hover:shadow-[0_2px_10px_rgba(139,92,246,0.16)]",
+  },
+  {
+    label: "학원",
+    icon: University,
+    className:
+      "bg-[#e0e7ff] text-[#4f46e5] shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] hover:bg-[#dbeafe] hover:shadow-[0_2px_10px_rgba(79,70,229,0.16)]",
+  },
+  {
+    label: "학교",
+    icon: GraduationCap,
+    className:
+      "bg-[#fff0e8] text-[#f06000] shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] hover:bg-[#ffedd5] hover:shadow-[0_2px_10px_rgba(240,96,0,0.16)]",
+  },
+] as const;
+
 export function AptSummaryCard({ name, address, x, y }: Props) {
   return (
-    <Card className="overflow-hidden ">
+    <Card className="overflow-hidden border-white/80 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]">
       <CardHeader>
         <div className="flex flex-wrap items-center gap-2">
           <span className="inline-flex items-center gap-1 rounded-full bg-[#e8f3ff] px-2.5 py-1 text-xs font-semibold text-[#3182f6]">
@@ -24,6 +57,21 @@ export function AptSummaryCard({ name, address, x, y }: Props) {
       </CardHeader>
       <CardContent className="space-y-3">
         <p className="text-sm text-[#4e5968]">{address || "주소 정보가 없습니다."}</p>
+        <div className="flex flex-1 flex-wrap gap-2">
+          {summaryTags.map(({ label, icon: Icon, className }) => (
+            <span
+              key={label}
+              className={[
+                "inline-flex items-center gap-2 rounded-2xl border border-white/70 px-3 py-1.5 text-sm font-medium",
+                "transition-all duration-200 hover:cursor-pointer",
+                className,
+              ].join(" ")}
+            >
+              <Icon size={16} strokeWidth={2.2} />
+              <span>{label}</span>
+            </span>
+          ))}
+        </div>
         <KakaoMiniMap x={x} y={y} />
       </CardContent>
     </Card>

--- a/src/widgets/report-sections/ui/AcademyCard.tsx
+++ b/src/widgets/report-sections/ui/AcademyCard.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export function AcademyCard({ count, academy }: Props) {
   return (
-    <Card>
+      <Card className="overflow-hidden border-white/80 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]">
       <CardHeader>
         <div className="flex items-center gap-2">
           <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#E0E7FF]">

--- a/src/widgets/report-sections/ui/ChildcareCard.tsx
+++ b/src/widgets/report-sections/ui/ChildcareCard.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export function ChildcareCard({ count, top5 }: Props) {
   return (
-    <Card>
+      <Card className="overflow-hidden border-white/80 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]">
       <CardHeader>
         <div className="flex items-center gap-2">
           <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#fff0f0]">

--- a/src/widgets/report-sections/ui/SafetyCard.tsx
+++ b/src/widgets/report-sections/ui/SafetyCard.tsx
@@ -21,7 +21,7 @@ function gradeTone(grade: string): string {
 
 export function SafetyCard({ fullName, grade, crimePer100k }: Props) {
   return (
-    <Card>
+      <Card className="overflow-hidden border-white/80 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]">
       <CardHeader>
         <div className="flex items-center gap-2">
           <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#e5f9f0]">

--- a/src/widgets/report-sections/ui/SchoolCard.tsx
+++ b/src/widgets/report-sections/ui/SchoolCard.tsx
@@ -24,7 +24,7 @@ export function SchoolCard({
 }: Props) {
   return (
     <>
-      <Card>
+      <Card className="overflow-hidden border-white/80 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]">
         <CardHeader>
           <div className="flex items-center gap-2">
             <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#fff0e8]">

--- a/src/widgets/report-sections/ui/TransportCard.tsx
+++ b/src/widgets/report-sections/ui/TransportCard.tsx
@@ -34,7 +34,7 @@ export function TransportCard({ subwayTop3, busCount, busTop5, distance }: Props
   ];
 
   return (
-    <Card>
+      <Card className="overflow-hidden border-white/80 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]">
       <CardHeader>
         <div className="flex items-center gap-2">
           <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#e8f3ff]">

--- a/src/widgets/report-sections/ui/infraCard.tsx
+++ b/src/widgets/report-sections/ui/infraCard.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export function InfraCard({ count, hospital, pharmacy }: Props) {
   return (
-    <Card>
+      <Card className="overflow-hidden border-white/80 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]">
       <CardHeader>
         <div className="flex items-center gap-2">
           <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F3EEFF]">


### PR DESCRIPTION
#### 이슈번호
#26 

#### 요약본
- AptSummaryCard의 hover 스타일 개선

#### 스크린샷

<img width="1186" height="577" alt="스크린샷 2026-04-06 오후 9 39 20" src="https://github.com/user-attachments/assets/fff82bd4-5874-4332-bcff-b7fa68e53ff5" />
